### PR TITLE
Allow created Gson instance to be accessed publically

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/lib/parser/ViewBuilder.java
+++ b/library/src/main/java/com/cube/storm/ui/lib/parser/ViewBuilder.java
@@ -49,7 +49,7 @@ public abstract class ViewBuilder
 	 *
 	 * @return The gson object
 	 */
-	private Gson getGson()
+	public Gson getGson()
 	{
 		if (viewBuilder == null)
 		{


### PR DESCRIPTION
This allows the caller to use or manipulate the gson instance that has been created. 
An example of this would be to use the gson instance to create a GsonConverterFactory for use with Retrofit.