### PR TITLE
Ensure child width is passed through when measuring ViewPager child, …

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/view/WrapContentViewPager.java
+++ b/library/src/main/java/com/cube/storm/ui/view/WrapContentViewPager.java
@@ -31,7 +31,10 @@ public class WrapContentViewPager extends ViewPager
 			int height = 0;
 			for (int i = 0; i < getChildCount(); i++) {
 				View child = getChildAt(i);
-				child.measure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+				child.measure(
+					MeasureSpec.makeMeasureSpec(child.getMeasuredWidth(), MeasureSpec.EXACTLY),
+					MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+				);
 				int h = child.getMeasuredHeight();
 				if (h > height) height = h;
 			}


### PR DESCRIPTION
…instead of the ViewPager width. Doing the former resulted in inaccurate heights, leading to rendering defects