### PR TITLE
hotfix/talk-back-navigation-tabs-correction Fix: Change getCurrentIte…

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
+++ b/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
@@ -83,6 +83,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			}
 		}
 
+		setTabItemContentDescriptions();
 		viewPager.setCurrentItem(selectedTab, true);
 		bottomNavigation.setTitleState(AHBottomNavigation.TitleState.ALWAYS_SHOW);
 		bottomNavigation.setOnTabSelectedListener(this);

--- a/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
+++ b/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
@@ -83,7 +83,6 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			}
 		}
 
-		setTabItemContentDescriptions();
 		viewPager.setCurrentItem(selectedTab, true);
 		bottomNavigation.setTitleState(AHBottomNavigation.TitleState.ALWAYS_SHOW);
 		bottomNavigation.setOnTabSelectedListener(this);
@@ -202,7 +201,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			View tab = bottomNavigation.getViewAtPosition(bottomTabIdx);
 			if (tab != null)
 			{
-				String formatString = bottomNavigation.getCurrentItem() == bottomTabIdx ? getString(R.string.bottom_navigation_tab_selected) : getString(R.string.bottom_navigation_tab);
+				String formatString = selectedTab == bottomTabIdx ? getString(R.string.bottom_navigation_tab_selected) : getString(R.string.bottom_navigation_tab);
 				String tabContentDescription = String.format(formatString, tabTitles.get(bottomTabIdx), bottomTabIdx + 1, tabCount);
 				tab.setContentDescription(tabContentDescription);
 				tab.setFocusable(true);


### PR DESCRIPTION
Changed getCurrentItem method by selectedTab because that method gets the previously selected tab, so the content description is outdated for talkback. And removed setTabItemContentDescriptions() call from loadPages because it is not necessary, that method is triggered on onTabSelected method.
