### PR TITLE
hotfix/talk-back-navigation-tabs-correction Fix: Add onLayoutChange l…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.4-SNAPSHOT
+VERSION_NAME=1.2.4
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.3
+VERSION_NAME=1.2.4-SNAPSHOT
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
+++ b/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
@@ -36,7 +36,7 @@ import lombok.Getter;
 /**
  * Renders a Storm TabbedPageCollection as a bottom tabs view.
  */
-public class StormBottomTabsFragment extends StormTabbedFragment implements AHBottomNavigation.OnTabSelectedListener
+public class StormBottomTabsFragment extends StormTabbedFragment implements AHBottomNavigation.OnTabSelectedListener, AHBottomNavigation.OnLayoutChangeListener
 {
 	private static final String EXTRA_SELECTED_TAB = "selectedTab";
 	public static final int MAX_BOTTOM_TABS = 5;
@@ -83,10 +83,10 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			}
 		}
 
-		setTabItemContentDescriptions();
 		viewPager.setCurrentItem(selectedTab, true);
 		bottomNavigation.setTitleState(AHBottomNavigation.TitleState.ALWAYS_SHOW);
 		bottomNavigation.setOnTabSelectedListener(this);
+		bottomNavigation.addOnLayoutChangeListener(this);
 		setAccentColorFromBottomNavigation();
 	}
 
@@ -171,7 +171,6 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 	{
 		viewPager.setCurrentItem(position);
 		selectedTab = position;
-		setTabItemContentDescriptions();
 
 		if (getActivity() != null && ((AppCompatActivity)getActivity()).getSupportActionBar() != null)
 		{    //Hide the back arrow in the main activity
@@ -185,19 +184,20 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 		return true;
 	}
 
+	// When the bottomNavigation layout change, set the tab item content descriptions for every tab
+	@Override public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom)
+	{
+		setTabItemContentDescriptions();
+	}
+
 	/**
 	 * This method set the content descriptions for all items from the bottom navigation menu.
 	 * Check if the current tab is selected to update the content description comment
 	 */
 	private void setTabItemContentDescriptions()
 	{
-		if (viewPager.getAdapter() == null)
-		{
-			return;
-		}
 		int tabCount = bottomNavigation.getItemsCount();
-		int maxElements = Math.min(viewPager.getAdapter().getCount(), MAX_BOTTOM_TABS);
-		for (int bottomTabIdx = 0; bottomTabIdx < maxElements; bottomTabIdx++)
+		for (int bottomTabIdx = 0; bottomTabIdx < tabCount; bottomTabIdx++)
 		{
 			View tab = bottomNavigation.getViewAtPosition(bottomTabIdx);
 			if (tab != null)


### PR DESCRIPTION
**SUMMARY**
Added the _onLayoutChange_ listener to set the tab item content descriptions for every tab when the _bottomNavigation_ layout change. Despite that method is called twice, it is trigger when the app starts, and when the user changes the tab. Furthermore, I removed unused calls and code. The bottom navigation menu won't change if the user comes back from another screen like info or preferences.

**CHANGES MADE**
- On _StormBottomTabsFragment_ class, added _OnLayoutChangeListener_ to call the method which populates the contentDescriptions, removed unnecessary calls from _loadPages_ and _onTabSelected_ methods, and deleted unused code.