### PR TITLE
hotfix/list-page-upgrade Fix: Add the constructor only with ListItem

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.1
+VERSION_NAME=1.4.2
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/ui/model/page/ListPage.java
+++ b/library/src/main/java/com/cube/storm/ui/model/page/ListPage.java
@@ -30,6 +30,11 @@ public class ListPage extends Page
 		this.className = CLASS_NAME;
 	}
 
+	public ListPage(Collection<ListItem> children)
+	{
+		this.children = children;
+	}
+
 	/**
 	 * The array list of audios {@link VideoProperty}
 	 */


### PR DESCRIPTION
**SUMMARY**

Add the constructor only with ListItem in case we need to load different Storm pages