### PR TITLE
Hotfix/manage correct button navigation tabs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.2
+VERSION_NAME=1.4.3-SNAPSHOT
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.3-SNAPSHOT
+VERSION_NAME=1.4.3
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
+++ b/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
@@ -5,10 +5,6 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.core.content.res.ResourcesCompat;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -31,6 +27,10 @@ import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListene
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.res.ResourcesCompat;
 import lombok.Getter;
 
 /**
@@ -72,7 +72,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 	protected void loadPages(@NonNull TabbedPageCollection collection)
 	{
 		super.loadPages(collection);
-		int maxElements = Math.min(collection.getPages().size(), MAX_BOTTOM_TABS);
+		int maxElements = Math.min(pageAdapter.getPages().size(), MAX_BOTTOM_TABS);
 		// It creates a bottom tab element for 5 adapter items or less
 		for (int bottomTabIdx = 0; bottomTabIdx < maxElements; bottomTabIdx++)
 		{


### PR DESCRIPTION
**TASK**

https://3sidedcube.atlassian.net/browse/GDPCFA-706

**SUMMARY**

On the `loadPages` method from `StormTabbedFragment` class, if a `FragmentIntent` object is null, that object is not added

```
...
if (collection.getPages() != null)
{
    for (TabbedPageDescriptor tabbedPageDescriptor : collection.getPages())
    {
        FragmentIntent fragmentIntent = UiSettings.getInstance().getIntentFactory().getFragmentIntentForPageDescriptor(tabbedPageDescriptor);

        if (fragmentIntent != null)
        {
            FragmentPackage fragmentPackage = new FragmentPackage(fragmentIntent, tabbedPageDescriptor);
            fragmentPages.add(fragmentPackage);
        }
    }
}
...
```

So, on `loadPages` from `StormBottomLoadFragment` class, if a `FragmentIntent` object was not added from the collection, we will got an `IndexOutOfBoundsException` error because the min number of pages is depending on the `collection.getPages().size()`, and that's why the Haiti app is failing

```
...
int maxElements = Math.min(collection.getPages().size(), MAX_BOTTOM_TABS);
// It creates a bottom tab element for 5 adapter items or less
for (int bottomTabIdx = 0; bottomTabIdx < maxElements; bottomTabIdx++)
{
    PageDescriptor pageDescriptor = pageAdapter.getPages().get(bottomTabIdx).getPageDescriptor();
    if (pageDescriptor instanceof TabbedPageDescriptor)
    {
        addTabBarItemToBottomTabs((TabbedPageDescriptor)pageDescriptor);
    }
}
...
```

What I have done is replacing the pages from the `TabbedPageCollection` to the `pageAdapter` because that has all the available pages.

```
...
int maxElements = Math.min(pageAdapter.getPages().size(), MAX_BOTTOM_TABS);
...
```