### PR TITLE
Fix infinite loop bug in getCurrentLanguageAudioFile

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/model/page/ListPage.java
+++ b/library/src/main/java/com/cube/storm/ui/model/page/ListPage.java
@@ -6,6 +6,7 @@ import com.cube.storm.ui.model.list.ListItem;
 import com.cube.storm.ui.model.property.VideoProperty;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Locale;
 
 import lombok.AllArgsConstructor;
@@ -59,9 +60,11 @@ public class ListPage extends Page
 		VideoProperty videoProperty;
 		VideoProperty auxVideoProperty = null;
 
-		while (audio.iterator().hasNext())
+		Iterator<VideoProperty> iterator = audio.iterator();
+
+		while (iterator.hasNext())
 		{
-			videoProperty = audio.iterator().next();
+			videoProperty = iterator.next();
 			String[] localeArray = videoProperty.getLocale().split("_");
 
 			if (localeArray[1] != null && Locale.getDefault().getLanguage().equals(new Locale(localeArray[1]).getLanguage()))


### PR DESCRIPTION
**Description**

The `getCurrentLanguageAudioFile()` method in `ListPage` had a bug whereby if

- `audio` contains at least one item
- The user's language does not match the language of items in `audio`

the method would get stuck in an infinite loop.

This was due to new iterators being created inline in the `while` loop, rather than the creation of a single iterator.
In essence, `audio.iterator().hasNext()` will always be true, as it creates a new iterator whose next item is always the first item in `audio`.
Then, if the user's language does not match, the `return` statement is never reached, and so the method cannot exit the `while` loop.

**Changes made**

Create a single iterator over `audio` before the `while` loop, and replaced all calls to `audio.iterator()` in the loop with this iterator.