### PR TITLE
Calling the click handler for the LogoListItemView

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.4
+VERSION_NAME=1.4.5
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Aug 05 14:24:50 BST 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library/src/main/java/com/cube/storm/ui/view/holder/list/LogoListItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/view/holder/list/LogoListItemViewHolder.java
@@ -57,7 +57,7 @@ public class LogoListItemViewHolder extends ViewHolder<LogoListItem>
 						eventHook.onViewLinkedClicked(itemView, model, model.getLink());
 					}
 
-					linkTitle.callOnClick();
+					UiSettings.getInstance().getLinkHandler().handleLink(image.getContext(), model.getLink());
 				}
 			});
 		}


### PR DESCRIPTION
The LogoListItemView class was not calling the click handler because a LogoListItemView doesn't have a text content, so the `linkTitle.callOnClick()` wouldn't register a callback. I added the `UiSettings.getInstance().getLinkHandler().handleLink(image.getContext(), model.getLink())` to call it the same way the `StandardListItemView` does. 