### PR TITLE
Feature/allow chevrons on standard list item

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.5
+VERSION_NAME=1.4.6
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/UiSettings.java
+++ b/library/src/main/java/com/cube/storm/UiSettings.java
@@ -606,7 +606,7 @@ public class UiSettings
 		 *
 		 * @return The {@link com.cube.storm.UiSettings.Builder} instance for chaining
 		 */
-		public Builder chevronSpec(ChevronSpec spec)
+		public Builder chevronSpec(@NonNull ChevronSpec spec)
 		{
 			construct.chevronSpec = spec;
 			return this;

--- a/library/src/main/java/com/cube/storm/UiSettings.java
+++ b/library/src/main/java/com/cube/storm/UiSettings.java
@@ -21,6 +21,7 @@ import com.cube.storm.ui.lib.resolver.AppResolver;
 import com.cube.storm.ui.lib.resolver.IntentResolver;
 import com.cube.storm.ui.lib.resolver.IntentResolverMap;
 import com.cube.storm.ui.lib.resolver.ViewResolver;
+import com.cube.storm.ui.lib.spec.ChevronSpec;
 import com.cube.storm.ui.lib.spec.DividerSpec;
 import com.cube.storm.ui.lib.spec.ListDividerSpec;
 import com.cube.storm.ui.model.App;
@@ -182,6 +183,11 @@ public class UiSettings
 	 * Default language Uri
 	 */
 	@Getter @Setter private String defaultLanguageUri = "";
+	
+	/**
+	 * Chevron spec to use for {@link com.cube.storm.ui.view.holder.list.StandardListItemViewHolder}s throughout the app
+	 */
+	@Getter @Setter private ChevronSpec chevronSpec;
 
 	/**
 	 * Sets the app model of the content
@@ -260,6 +266,7 @@ public class UiSettings
 
 			viewBuilder(new ViewBuilder(){});
 			dividerSpec(new ListDividerSpec());
+			chevronSpec(ChevronSpec.noChevronSpec());
 		}
 
 		/**
@@ -589,6 +596,19 @@ public class UiSettings
 		{
 			construct.youtubeApiKey = youtubeApiKey;
 			isYouTubeAPIKeyInitialised = true;
+			return this;
+		}
+		
+		/**
+		 * Sets the app to display chevrons on StandardListItemView if the link matches the correct criteria
+		 *
+		 * If not set, StandardListItemView will not display with chevrons
+		 *
+		 * @return The {@link com.cube.storm.UiSettings.Builder} instance for chaining
+		 */
+		public Builder chevronSpec(ChevronSpec spec)
+		{
+			construct.chevronSpec = spec;
 			return this;
 		}
 

--- a/library/src/main/java/com/cube/storm/ui/lib/spec/ChevronSpec.java
+++ b/library/src/main/java/com/cube/storm/ui/lib/spec/ChevronSpec.java
@@ -53,6 +53,10 @@ public abstract class ChevronSpec
 		{
 			@Override public boolean shouldChevronShow(StandardListItem model)
 			{
+				if(model == null)
+				{
+					return false;
+				}
 				LinkProperty link = model.getLink();
 				return link != null && (
 					(link instanceof DestinationLinkProperty && !TextUtils.isEmpty(((DestinationLinkProperty)link).getDestination()))

--- a/library/src/main/java/com/cube/storm/ui/lib/spec/ChevronSpec.java
+++ b/library/src/main/java/com/cube/storm/ui/lib/spec/ChevronSpec.java
@@ -1,0 +1,82 @@
+package com.cube.storm.ui.lib.spec;
+
+import android.text.TextUtils;
+
+import com.cube.storm.ui.model.list.StandardListItem;
+import com.cube.storm.ui.model.property.DestinationLinkProperty;
+import com.cube.storm.ui.model.property.LinkProperty;
+import com.cube.storm.ui.model.property.ShareLinkProperty;
+import com.cube.storm.ui.view.holder.list.StandardListItemViewHolder;
+
+/**
+ * Specification abstract class used to determine whether a chevron should be shown on each {@link StandardListItemViewHolder}.
+ * Use this abstract class along with {@link com.cube.storm.UiSettings#setChevronSpec(ChevronSpec)} to change the default spec.
+ * Currently defaults to {@link ChevronSpec#noChevronSpec()}.
+ *
+ * @author JR Mitchell
+ * @project LightningUI
+ */
+public abstract class ChevronSpec
+{
+	/**
+	 * Determines whether a chevron should be shown based on the {@link StandardListItem} that it is populated with.
+	 *
+	 * @param model the model that the {@link StandardListItemViewHolder} is populated with
+	 * @return true if the UI element should show a chevron, else false.
+	 */
+	abstract public boolean shouldChevronShow(StandardListItem model);
+	
+	/**
+	 * Get an instance of {@link ChevronSpec} that never shows chevrons
+	 *
+	 * @return the new {@link ChevronSpec} instance
+	 */
+	public static ChevronSpec noChevronSpec()
+	{
+		return new ChevronSpec()
+		{
+			@Override public boolean shouldChevronShow(StandardListItem model)
+			{
+				return false;
+			}
+		};
+	}
+	
+	/**
+	 * Get an instance of {@link ChevronSpec} that shows chevrons in a standard way which matches with iOS Storm behaviour.
+	 *
+	 * @return the new {@link ChevronSpec} instance
+	 */
+	public static ChevronSpec standardChevronSpec()
+	{
+		return new ChevronSpec()
+		{
+			@Override public boolean shouldChevronShow(StandardListItem model)
+			{
+				LinkProperty link = model.getLink();
+				return link != null && (
+					(link instanceof DestinationLinkProperty && !TextUtils.isEmpty(((DestinationLinkProperty)link).getDestination()))
+					|| link instanceof ShareLinkProperty
+					//|| link instanceof EmergencyLinkProperty || link instanceof TimerLinkProperty
+					//NOTE: the above commented-out LinkProperty types appear to exist in iOS Storm library but not Android Storm library
+				);
+			}
+		};
+	}
+	
+	/**
+	 * Get an instance of {@link ChevronSpec} that always shows chevrons
+	 *
+	 * @return the new {@link ChevronSpec} instance
+	 */
+	public static ChevronSpec allChevronSpec()
+	{
+		return new ChevronSpec()
+		{
+			@Override public boolean shouldChevronShow(StandardListItem model)
+			{
+				return true;
+			}
+		};
+	}
+}

--- a/library/src/main/java/com/cube/storm/ui/view/holder/list/StandardListItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/view/holder/list/StandardListItemViewHolder.java
@@ -39,6 +39,7 @@ public class StandardListItemViewHolder extends ViewHolder<StandardListItem>
 	protected TextView description;
 	protected LinkProperty link;
 	protected LinearLayout embeddedLinksContainer;
+	protected android.widget.ImageView chevron;
 
 	public StandardListItemViewHolder(View view)
 	{
@@ -48,6 +49,7 @@ public class StandardListItemViewHolder extends ViewHolder<StandardListItem>
 		title = (TextView)view.findViewById(R.id.title);
 		description = (TextView)view.findViewById(R.id.description);
 		embeddedLinksContainer = (LinearLayout)view.findViewById(R.id.embedded_links_container);
+		chevron = (android.widget.ImageView)view.findViewById(R.id.chevron);
 	}
 
 	@Override public void populateView(final StandardListItem model)
@@ -76,6 +78,18 @@ public class StandardListItemViewHolder extends ViewHolder<StandardListItem>
 					UiSettings.getInstance().getLinkHandler().handleLink(image.getContext(), link);
 				}
 			});
+		}
+		
+		if (chevron != null)
+		{
+			if(UiSettings.getInstance().getChevronSpec().shouldChevronShow(model))
+			{
+				chevron.setVisibility(View.VISIBLE);
+			}
+			else
+			{
+				chevron.setVisibility(View.GONE);
+			}
 		}
 	}
 }

--- a/library/src/main/res/drawable/ic_chevron.xml
+++ b/library/src/main/res/drawable/ic_chevron.xml
@@ -1,0 +1,14 @@
+<vector
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:autoMirrored="true"
+	android:height="13dp"
+	android:viewportHeight="13"
+	android:viewportWidth="9"
+	android:width="9dp">
+	<path
+		android:fillColor="#C7C7CC"
+		android:fillType="evenOdd"
+		android:pathData="M6.0946,6.4999l-6.0946,-5.2499l1.4511,-1.25l7.5489,6.4999l-7.5489,6.5001l-1.4511,-1.25z"
+		android:strokeColor="#00000000"
+		android:strokeWidth="1" />
+</vector>

--- a/library/src/main/res/layout/standard_list_item_view.xml
+++ b/library/src/main/res/layout/standard_list_item_view.xml
@@ -57,4 +57,22 @@
 			android:visibility="gone"
 		/>
 	</LinearLayout>
+
+	<!-- View for spacing chevron ImageView to the end -->
+	<View
+		android:layout_width="0dp"
+		android:layout_height="0dp"
+		android:layout_weight="1"
+		android:importantForAccessibility="no"
+		android:visibility="invisible"/>
+
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:id="@+id/chevron"
+		android:src="@drawable/ic_chevron"
+		android:layout_gravity="center_vertical"
+		android:importantForAccessibility="no"
+		android:visibility="visible"
+		android:layout_marginStart="16dp"/>
 </LinearLayout>

--- a/library/src/main/res/layout/standard_list_item_view.xml
+++ b/library/src/main/res/layout/standard_list_item_view.xml
@@ -22,8 +22,9 @@
 	/>
 
 	<LinearLayout
-		android:layout_width="wrap_content"
+		android:layout_width="0dp"
 		android:layout_height="wrap_content"
+		android:layout_weight="1"
 		android:orientation="vertical"
 		android:layout_gravity="center_vertical"
 	>
@@ -58,14 +59,6 @@
 		/>
 	</LinearLayout>
 
-	<!-- View for spacing chevron ImageView to the end -->
-	<View
-		android:layout_width="0dp"
-		android:layout_height="0dp"
-		android:layout_weight="1"
-		android:importantForAccessibility="no"
-		android:visibility="invisible"/>
-
 	<ImageView
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
@@ -74,5 +67,6 @@
 		android:layout_gravity="center_vertical"
 		android:importantForAccessibility="no"
 		android:visibility="gone"
-		android:layout_marginStart="16dp"/>
+		android:layout_marginStart="16dp"
+	/>
 </LinearLayout>

--- a/library/src/main/res/layout/standard_list_item_view.xml
+++ b/library/src/main/res/layout/standard_list_item_view.xml
@@ -73,6 +73,6 @@
 		android:src="@drawable/ic_chevron"
 		android:layout_gravity="center_vertical"
 		android:importantForAccessibility="no"
-		android:visibility="visible"
+		android:visibility="gone"
 		android:layout_marginStart="16dp"/>
 </LinearLayout>


### PR DESCRIPTION
### What?

- Added `ic_chevron.xml` resource
- Updated `standard_list_item_view.xml` with a chevron `ImageView` pushed to the end by an invisible spacing view
- Create `ChevronSpec` abstract class for determining whether a chevron should be shown on a `StandardListItem` depending on its model
- Add three useful static methods for common chevron specs (never show chevrons, always show chevrons, and show chevrons under the same circumstances that the iOS app does)
- Make the `UiSettings` class contain an instance of `ChevronSpec`
- Add methods and properties to the `UiSettings.Builder()` so that settings can be built with a particular `ChevronSpec`, and defaulting to not showing chevrons if not set.
- Update `StandardListItemViewHolder.populateView()` so that the visibility of the chevron (if one is found by `findViewById()`) is determined by the `UiSettings.chevronSpec`.
- Bump version code to 1.4.6

### Why?

The [iOS Storm UI library, ThunderCloud, has had chevrons on its `StandardListItem`s since 2017](https://github.com/3sidedcube/ThunderCloud/blob/master/ThunderCloud/StandardListItem.swift).
Since chevrons were an iOS-style design feature, and didn't align with Android design patterns at the time, this behaviour was not implemented in LightningUi at the time.
However, it is now a requested feature to be able to have chevrons on these items in order to align the appearance of iOS and Android storm apps.

This update does not change the appearance of `StandardListItem` by default, so that any app updating Storm version will not suddenly have chevrons appear even if they don't want them.
Instead, each app can be configured with a `ChevronSpec` to determine whether (and under what circumstances) chevrons should show.

### Screenshots / Attachments

No screenshots here, I'll be attaching screenshots to each of the internal app PRs relating to this change, so please don't approve this PR until you are happy with each of these.

### Anything else?

I haven't _yet_ published this to v1.4.6, only to v1.4.6-SNAPSHOT.
I'll do this after all parts of this update have been approved (including updates to internal apps).