### PR TITLE
Fixed issue where expanded state was not retained.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.7
+VERSION_NAME=1.4.8
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/ui/model/list/ToggleableListItem.java
+++ b/library/src/main/java/com/cube/storm/ui/model/list/ToggleableListItem.java
@@ -18,8 +18,29 @@ import lombok.experimental.Accessors;
 public class ToggleableListItem extends DescriptionListItem
 {
 	public static String CLASS_NAME = "ToggleableListItem";
+	private boolean expanded = false;
 
 	{ this.className = CLASS_NAME; }
+
+	/**
+	 * Sets the model's expanded state to either true or false
+	 *
+	 * @param expanded whether or not the view has been expanded
+	 */
+	public void setExpanded(boolean expanded)
+	{
+		this.expanded = expanded;
+	}
+
+	/**
+	 * Gets the model's expanded state as either true or false
+	 *
+	 * @return true if expanded, false if collapsed
+	 */
+	public boolean getExpanded()
+	{
+		return expanded;
+	}
 
 	@Override public int describeContents()
 	{

--- a/library/src/main/java/com/cube/storm/ui/view/holder/list/ToggleableListItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/view/holder/list/ToggleableListItemViewHolder.java
@@ -74,17 +74,8 @@ public class ToggleableListItemViewHolder extends ViewHolder<ToggleableListItem>
 		description.populate(model.getDescription());
 		Populator.populate(embeddedLinksContainer, model.getEmbeddedLinks());
 
-		toggleContainer.setVisibility(View.GONE);
-		embeddedLinksContainer.setVisibility(View.GONE);
-
-		if (toggleContainer.getTag() != null && (Boolean)toggleContainer.getTag())
-		{
-			toggleContainer.setVisibility(View.VISIBLE);
-			if (!TextUtils.isEmpty(titleText))
-			{
-				title.setContentDescription(titleText +  ". Description expanded");
-			}
-		}
+		// Use model field instead of View#getTag() which is always null
+		expandContainer(model.getExpanded(), model);
 
 		itemView.setOnClickListener(new OnClickListener()
 		{
@@ -95,23 +86,36 @@ public class ToggleableListItemViewHolder extends ViewHolder<ToggleableListItem>
 					eventHook.onViewClicked(itemView, model);
 				}
 
-				if (toggleContainer.getVisibility() == View.GONE)
-				{
-					toggleContainer.setTag(true);
-					toggleContainer.setVisibility(View.VISIBLE);
-					expandIcon.setImageResource(R.drawable.ic_collapse);
-					embeddedLinksContainer.setVisibility(View.VISIBLE);
-					title.setContentDescription(titleText + ". Description expanded");
-				}
-				else
-				{
-					toggleContainer.setTag(false);
-					toggleContainer.setVisibility(View.GONE);
-					expandIcon.setImageResource(R.drawable.ic_expand);
-					embeddedLinksContainer.setVisibility(View.GONE);
-					title.setContentDescription(titleText + ". Description collapsed");
-				}
+				// Invert expansion state when clicked
+				expandContainer(!model.getExpanded(), model);
 			}
 		});
+	}
+
+	/**
+	 * Expands a {@link ToggleableListItem} and retains it's expanded state for
+	 * redrawing the view when scrolling
+	 *
+	 * @param expand true to expand, false to collapse
+	 * @param model the model with which to persist the expanded state
+	 */
+	private void expandContainer(boolean expand, ToggleableListItem model)
+	{
+		toggleContainer.setTag(expand);
+		model.setExpanded(expand);
+		if (expand)
+		{
+			toggleContainer.setVisibility(View.VISIBLE);
+			expandIcon.setImageResource(R.drawable.ic_collapse);
+			embeddedLinksContainer.setVisibility(View.VISIBLE);
+			title.setContentDescription(titleText + ". Description expanded");
+		}
+		else
+		{
+			toggleContainer.setVisibility(View.GONE);
+			expandIcon.setImageResource(R.drawable.ic_expand);
+			embeddedLinksContainer.setVisibility(View.GONE);
+			title.setContentDescription(titleText + ". Description collapsed");
+		}
 	}
 }


### PR DESCRIPTION
### What?
- Added `expanded` field to `ToggleableListItem` + getters/setters
- Refactored expand/collapse logic in `ToggleableListItemViewHolder` to call private method as well as use the new `expanded` field which doesn't get nulled out on scroll.
### Why?
[SP-432 - [ARC] Blood - Storm pages collapsing when not visible on screen](https://3sidedcube.atlassian.net/browse/SP-432)
### Testing?
- Tested with the example project and it fixes the issue
- `1.4.8-SNAPSHOT` tested with ARC-Blood and this change also fixes the issue we were seeing there.
### Anything else?
Will publish `1.4.8` once approved.

https://user-images.githubusercontent.com/18074024/139867122-616eca2a-b7dd-46e2-b4fe-8edc8dacf750.mp4

