### PR TITLE
[NOR] Added close button to storm video activities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.4.8
+VERSION_NAME=1.4.9
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningUi

--- a/library/src/main/java/com/cube/storm/ui/activity/VideoPlayerActivity.java
+++ b/library/src/main/java/com/cube/storm/ui/activity/VideoPlayerActivity.java
@@ -9,6 +9,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
@@ -81,6 +82,7 @@ public class VideoPlayerActivity extends AppCompatActivity implements PlaybackPr
 	private int startWindow;
 	private long startPosition;
 	private ImageButton closedCaptionsButton;
+	private ImageView closeVideoButton;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState)
@@ -90,7 +92,9 @@ public class VideoPlayerActivity extends AppCompatActivity implements PlaybackPr
 		setContentView(R.layout.activity_video_player);
 
 		closedCaptionsButton = findViewById(R.id.cc_button);
+		closeVideoButton = findViewById(R.id.close_button);
 		closedCaptionsButton.setOnClickListener(this);
+		closeVideoButton.setOnClickListener(this);
 		playerView = findViewById(R.id.player_view);
 		progressBar = findViewById(R.id.progress);
 		playerView.requestFocus();
@@ -437,6 +441,10 @@ public class VideoPlayerActivity extends AppCompatActivity implements PlaybackPr
 			}
 
 			showTrackSelectorDialog(captionsRendererIdx);
+		}
+		else if (view == closeVideoButton)
+		{
+			finish();
 		}
 	}
 

--- a/library/src/main/res/drawable/ic_close.xml
+++ b/library/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/library/src/main/res/layout/activity_video_player.xml
+++ b/library/src/main/res/layout/activity_video_player.xml
@@ -21,6 +21,17 @@
 		android:visibility="visible"
 	/>
 
+	<ImageView
+		android:layout_width="24dp"
+		android:layout_height="24dp"
+		android:id="@+id/close_button"
+		android:src="@drawable/ic_close"
+		android:layout_gravity="top|start"
+		android:layout_marginTop="20dp"
+		android:layout_marginStart="10dp"
+		android:contentDescription="@string/close_video"
+		android:tint="@android:color/white" />
+
 	<ImageButton
 		android:layout_width="24dp"
 		android:layout_height="24dp"

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="closed_captions">Closed captions</string>
+	<string name="close_video">Close video</string>
 	<string name="bottom_navigation_tab">%1$s tab. %2$d of %3$d.</string>
 	<string name="bottom_navigation_tab_selected">%1$s tab. %2$d of %3$d selected.</string>
 </resources>


### PR DESCRIPTION
### What?
- Added `ic_close.xml` drawable resource 
- Added click listener for the `close_button` which calls `finish()`
- Bumped version number

### Why?
New requirement for all fullscreen videos to have a close button like iOS.

### Testing?
Tested on Android 12 and 11 with ARC FA using snapshot `1.4.9.1-SNAPSHOT`

### Screenshots?
![Screenshot_20211122_135505](https://user-images.githubusercontent.com/18074024/142874439-cf0a4323-54b3-4062-8311-5b870c129fbd.png)