### PR TITLE
:NORMAL: Feature/remove-jcenter [SMALL]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:7.0.3'
@@ -22,7 +22,8 @@ ext {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+
+		mavenCentral()
 
 		maven {
 			url 'http://oss.3sidedcube.com:8081/artifactory/internal'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,6 +11,7 @@ android {
 		targetSdkVersion rootProject.ext.targetSdkVersion
 		versionCode 1
 		versionName "1.0"
+		multiDexEnabled true
 	}
 
 	compileOptions {
@@ -25,6 +26,8 @@ android {
 
 dependencies {
 	implementation project(':library')
+
+	implementation 'androidx.multidex:multidex:2.0.1'
 
 	implementation 'androidx.appcompat:appcompat:1.4.0'
 	implementation 'com.3sidedcube.storm:util:1.1.2'

--- a/example/src/main/java/com/cube/storm/ui/example/MainApplication.java
+++ b/example/src/main/java/com/cube/storm/ui/example/MainApplication.java
@@ -1,9 +1,10 @@
 package com.cube.storm.ui.example;
 
-import android.app.Application;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.multidex.MultiDexApplication;
+
 import com.cube.storm.UiSettings;
 import com.cube.storm.ui.example.provider.CustomIntentProvider;
 import com.cube.storm.ui.fragment.StormStaticFragment;
@@ -19,7 +20,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.InputStream;
 import java.util.ArrayList;
 
-public class MainApplication extends Application
+public class MainApplication extends MultiDexApplication
 {
 	@Override public void onCreate()
 	{

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,6 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
-		multiDexEnabled true
 	}
 
 	compileOptions {
@@ -23,8 +22,6 @@ android {
 
 dependencies {
     implementation files('lib/YouTubeAndroidPlayerApi.jar')
-
-	implementation 'androidx.multidex:multidex:2.0.1'
 
 	// androidx libs
 	implementation 'androidx.annotation:annotation:1.3.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,6 +8,7 @@ android {
 	defaultConfig {
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
+		multiDexEnabled true
 	}
 
 	compileOptions {
@@ -23,6 +24,8 @@ android {
 dependencies {
     implementation files('lib/YouTubeAndroidPlayerApi.jar')
 
+	implementation 'androidx.multidex:multidex:2.0.1'
+
 	// androidx libs
 	implementation 'androidx.annotation:annotation:1.3.0'
 	implementation 'androidx.appcompat:appcompat:1.4.0'
@@ -33,9 +36,9 @@ dependencies {
 
 	implementation 'com.google.android.material:material:1.4.0'
 
-	api 'com.aurelhubert:ahbottomnavigation:2.3.4'
+	api 'com.github.aurelhubert:ahbottomnavigation:2.3.4'
 
-	implementation 'com.google.android.exoplayer:exoplayer:2.11.7'
+	implementation 'com.google.android.exoplayer:exoplayer:2.13.3'
 	implementation 'com.github.HaarigerHarald:android-youtubeExtractor:v1.7.0'
 
 	implementation 'com.google.code.gson:gson:2.8.6'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.cube.storm.ui"
-/>
+	package="com.cube.storm.ui">
+</manifest>


### PR DESCRIPTION
**What?**

- Removes JCenter from the build files
- Updates ExoPlayer to version 2.13.3 (earliest version on google's maven)
- Switch AhBottomNavigation to fork that has JCenter removed
- Enables multidex as references have exceeded 65K

**Why?**

- Need to remove JCenter from storm libraries to get our storm app building again
