### PR TITLE
:NORMAL: Feature/video list item localisation

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/view/holder/list/VideoListItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/view/holder/list/VideoListItemViewHolder.java
@@ -81,57 +81,66 @@ public class VideoListItemViewHolder extends ViewHolder<VideoListItem>
 		{
 			@Override public void onClick(View v)
 			{
-				try
-				{
-					List<VideoProperty> videoList = new ArrayList<>(model.getVideos());
-
-					if (videoList.isEmpty())
-					{
-						Toast.makeText(itemView.getContext(), "Video is not available", Toast.LENGTH_LONG).show();
-						return;
-					}
-
-					String defaultLanguageUri = UiSettings.getInstance().getDefaultLanguageUri();
-					VideoProperty videoToShow = videoList.get(0);
-					if (defaultLanguageUri != null)
-					{
-						// TODO: Some of this locale logic is duplicated with the language library - move to utils
-						for (VideoProperty videoProperty : model.getVideos())
-						{
-							if (defaultLanguageUri.contains(videoProperty.getLocale()))
-							{
-								videoToShow = videoProperty;
-								break;
-							}
-						}
-					}
-
-					for (EventHook eventHook : UiSettings.getInstance().getEventHooks())
-					{
-						eventHook.onViewLinkedClicked(itemView, model, videoToShow.getSrc());
-					}
-
-					VideoPageDescriptor pageDescriptor = new VideoPageDescriptor();
-					pageDescriptor.setType("content");
-					pageDescriptor.setSrc(videoToShow.getSrc().getDestination());
-
-					Intent video = UiSettings.getInstance().getIntentFactory().getIntentForPageDescriptor(v.getContext(), pageDescriptor);
-
-					if (video != null)
-					{
-						if (video.getComponent() != null && video.getComponent().getClassName().equals(VideoPlayerActivity.class.getName()))
-						{
-							video.putExtra(VideoPlayerActivity.EXTRA_VIDEO, videoToShow);
-						}
-						v.getContext().startActivity(video);
-					}
-				}
-				catch (Exception e)
-				{
-					Log.e(getClass().getName(), "Error: " + e.getMessage());
-					Toast.makeText(itemView.getContext(), "Could not load video", Toast.LENGTH_LONG).show();
-				}
+				onItemClick(v);
 			}
 		});
+	}
+	
+	/**
+	 * Method to call when the view is clicked
+	 * @param view The clicked view
+	 */
+	protected void onItemClick(View view)
+	{
+		try
+		{
+			List<VideoProperty> videoList = new ArrayList<>(model.getVideos());
+			
+			if (videoList.isEmpty())
+			{
+				Toast.makeText(itemView.getContext(), "Video is not available", Toast.LENGTH_LONG).show();
+				return;
+			}
+			
+			String defaultLanguageUri = UiSettings.getInstance().getDefaultLanguageUri();
+			VideoProperty videoToShow = videoList.get(0);
+			if (defaultLanguageUri != null)
+			{
+				// TODO: Some of this locale logic is duplicated with the language library - move to utils
+				for (VideoProperty videoProperty : model.getVideos())
+				{
+					if (defaultLanguageUri.contains(videoProperty.getLocale()))
+					{
+						videoToShow = videoProperty;
+						break;
+					}
+				}
+			}
+			
+			for (EventHook eventHook : UiSettings.getInstance().getEventHooks())
+			{
+				eventHook.onViewLinkedClicked(itemView, model, videoToShow.getSrc());
+			}
+			
+			VideoPageDescriptor pageDescriptor = new VideoPageDescriptor();
+			pageDescriptor.setType("content");
+			pageDescriptor.setSrc(videoToShow.getSrc().getDestination());
+			
+			Intent video = UiSettings.getInstance().getIntentFactory().getIntentForPageDescriptor(view.getContext(), pageDescriptor);
+			
+			if (video != null)
+			{
+				if (video.getComponent() != null && video.getComponent().getClassName().equals(VideoPlayerActivity.class.getName()))
+				{
+					video.putExtra(VideoPlayerActivity.EXTRA_VIDEO, videoToShow);
+				}
+				view.getContext().startActivity(video);
+			}
+		}
+		catch (Exception e)
+		{
+			Log.e(getClass().getName(), "Error: " + e.getMessage());
+			Toast.makeText(itemView.getContext(), "Could not load video", Toast.LENGTH_LONG).show();
+		}
 	}
 }

--- a/library/src/main/java/com/cube/storm/ui/view/holder/list/VideoListItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/view/holder/list/VideoListItemViewHolder.java
@@ -98,7 +98,7 @@ public class VideoListItemViewHolder extends ViewHolder<VideoListItem>
 			
 			if (videoList.isEmpty())
 			{
-				Toast.makeText(itemView.getContext(), "Video is not available", Toast.LENGTH_LONG).show();
+				onVideoNotAvailable();
 				return;
 			}
 			
@@ -140,7 +140,23 @@ public class VideoListItemViewHolder extends ViewHolder<VideoListItem>
 		catch (Exception e)
 		{
 			Log.e(getClass().getName(), "Error: " + e.getMessage());
-			Toast.makeText(itemView.getContext(), "Could not load video", Toast.LENGTH_LONG).show();
+			onVideoLoadFailed(e);
 		}
+	}
+	
+	/**
+	 * Displays to the user that a video is not available
+	 */
+	protected void onVideoNotAvailable()
+	{
+		Toast.makeText(itemView.getContext(), "Video is not available", Toast.LENGTH_LONG).show();
+	}
+	
+	/**
+	 * Displays to the user that a video could not be loaded
+	 */
+	protected void onVideoLoadFailed(@SuppressWarnings("unused") Exception e)
+	{
+		Toast.makeText(itemView.getContext(), "Could not load video", Toast.LENGTH_LONG).show();
 	}
 }


### PR DESCRIPTION
### What?
Factors logic from `VideoListItemViewHolder.populateView()` out into separate protected methods

### Why?
This makes it easier to override specific behaviours in apps using this library.
For instance, if an app needs custom on-click behaviour, or custom error logging, they can override just the `onItemClick()` or `onVideoLoadFailed()` methods, rather than having to copy-paste the entire behaviour of this class into a new `ViewHolder` class (and therefore missing out on any further updates from the point at which they copy-pasted)