### PR TITLE
:NORMAL: Chore/Replace ahbottomnavigation with Material bottom navigation [MEDIUM]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Apply to all files in the repository
+* @3sidedcube/android

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -11,9 +11,9 @@
 			</intent-filter>
 		</activity>
 
-		<activity android:name=".CustomStormActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-		<activity android:name="com.cube.storm.ui.activity.StormActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-		<activity android:name="com.cube.storm.ui.activity.StormWebActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-		<activity android:name="com.cube.storm.ui.activity.VideoPlayerActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+		<activity android:name=".CustomStormActivity" android:theme="@style/Theme.StormExample" />
+		<activity android:name="com.cube.storm.ui.activity.StormActivity" android:theme="@style/Theme.StormExample" />
+		<activity android:name="com.cube.storm.ui.activity.StormWebActivity" android:theme="@style/Theme.StormExample" />
+		<activity android:name="com.cube.storm.ui.activity.VideoPlayerActivity" android:theme="@style/Theme.StormExample" />
 	</application>
 </manifest>

--- a/example/src/main/res/color/example_bottom_nav_item.xml
+++ b/example/src/main/res/color/example_bottom_nav_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:color="@color/example_bottom_nav_selected" android:state_checked="true" />
+	<item android:color="@color/example_bottom_nav_unselected" />
+</selector>

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<color name="example_bottom_nav_selected">#424242</color>
+	<color name="example_bottom_nav_unselected">#9E9E9E</color>
+</resources>

--- a/example/src/main/res/values/themes.xml
+++ b/example/src/main/res/values/themes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<!--
+		Bridge theme keeps the existing AppCompat DarkActionBar look while enabling the
+		Material components (BottomNavigationView) used by the Storm library.
+	-->
+	<style name="Theme.StormExample" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
+		<item name="bottomNavigationStyle">@style/Widget.StormExample.BottomNavigationView</item>
+	</style>
+
+	<!--
+		Example app-level override of the bottom navigation colour. The library leaves the
+		bottom navigation untinted so each app can theme it; here we drive the labels gray.
+		Note: the library calls setItemIconTintList(null) so the icons render in their
+		original colours regardless of itemIconTint.
+	-->
+	<style name="Widget.StormExample.BottomNavigationView" parent="Widget.MaterialComponents.BottomNavigationView">
+		<item name="itemIconTint">@color/example_bottom_nav_item</item>
+		<item name="itemTextColor">@color/example_bottom_nav_item</item>
+	</style>
+</resources>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,30 +32,28 @@ dependencies {
     implementation files('lib/YouTubeAndroidPlayerApi.jar')
 
 	// androidx libs
-	implementation 'androidx.annotation:annotation:1.9.1'
+	implementation 'androidx.annotation:annotation:1.10.0'
 	implementation 'androidx.appcompat:appcompat:1.7.1'
-	implementation 'androidx.browser:browser:1.9.0'
+	implementation 'androidx.browser:browser:1.10.0'
 	implementation 'androidx.cardview:cardview:1.0.0'
 	implementation 'androidx.legacy:legacy-support-v13:1.0.0'
 	implementation 'androidx.recyclerview:recyclerview:1.4.0'
 
-	implementation 'com.google.android.material:material:1.13.0'
-
-	api 'com.github.aurelhubert:ahbottomnavigation:2.3.4'
+	implementation 'com.google.android.material:material:1.14.0'
 
 	implementation 'com.google.android.exoplayer:exoplayer:2.13.3'
 	implementation 'com.github.HaarigerHarald:android-youtubeExtractor:v1.7.0'
 	implementation 'com.google.guava:guava:31.1-android'
 
-	implementation 'com.google.code.gson:gson:2.13.2'
+	implementation 'com.google.code.gson:gson:2.14.0'
 
 	implementation 'com.3sidedcube.storm:util:1.3.0'
 
 	implementation 'com.github.bumptech.glide:glide:5.0.7'
 	annotationProcessor 'com.github.bumptech.glide:compiler:5.0.7'
 
-	compileOnly 'org.projectlombok:lombok:1.18.40'
-	annotationProcessor 'org.projectlombok:lombok:1.18.40'
+	compileOnly 'org.projectlombok:lombok:1.18.46'
+	annotationProcessor 'org.projectlombok:lombok:1.18.46'
 }
 
 apply from: '../gradle/publishing.gradle'

--- a/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
+++ b/library/src/main/java/com/cube/storm/ui/fragment/StormBottomTabsFragment.java
@@ -13,9 +13,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
-import com.aurelhubert.ahbottomnavigation.AHBottomNavigationItem;
-import com.aurelhubert.ahbottomnavigation.AHBottomNavigationViewPager;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.CustomTarget;
 import com.bumptech.glide.request.transition.Transition;
@@ -25,6 +22,8 @@ import com.cube.storm.ui.lib.helper.ImageHelper;
 import com.cube.storm.ui.model.descriptor.PageDescriptor;
 import com.cube.storm.ui.model.descriptor.TabbedPageDescriptor;
 import com.cube.storm.ui.model.page.TabbedPageCollection;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.navigation.NavigationBarView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,20 +32,18 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.res.ResourcesCompat;
 import android.graphics.drawable.Drawable;
 import lombok.Getter;
 
 /**
  * Renders a Storm TabbedPageCollection as a bottom tabs view.
  */
-public class StormBottomTabsFragment extends StormTabbedFragment implements AHBottomNavigation.OnTabSelectedListener, AHBottomNavigation.OnLayoutChangeListener
+public class StormBottomTabsFragment extends StormTabbedFragment implements NavigationBarView.OnItemSelectedListener, View.OnLayoutChangeListener
 {
 	private static final String EXTRA_SELECTED_TAB = "selectedTab";
 	public static final int MAX_BOTTOM_TABS = 5;
 
-	private AHBottomNavigationViewPager viewPager;
-	public AHBottomNavigation bottomNavigation;
+	public BottomNavigationView bottomNavigation;
 	@Getter private int selectedTab = 0;
 	@Getter private List<String> tabTitles = new ArrayList<>();
 
@@ -58,7 +55,6 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 		{
 			return null;
 		}
-		viewPager = view.findViewById(R.id.view_pager);
 		bottomNavigation = view.findViewById(R.id.bottom_tabs);
 
 		if (savedInstanceState != null && savedInstanceState.containsKey(EXTRA_SELECTED_TAB))
@@ -83,31 +79,28 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			PageDescriptor pageDescriptor = pageAdapter.getPages().get(bottomTabIdx).getPageDescriptor();
 			if (pageDescriptor instanceof TabbedPageDescriptor)
 			{
-				addTabBarItemToBottomTabs((TabbedPageDescriptor)pageDescriptor);
+				addTabBarItemToBottomTabs(bottomTabIdx, (TabbedPageDescriptor)pageDescriptor);
 			}
 		}
 
 		viewPager.setCurrentItem(selectedTab, true);
-		bottomNavigation.setTitleState(AHBottomNavigation.TitleState.ALWAYS_SHOW);
-		bottomNavigation.setOnTabSelectedListener(this);
+		bottomNavigation.setLabelVisibilityMode(NavigationBarView.LABEL_VISIBILITY_LABELED);
+		// Render icons with their original colours; consuming apps drive selection/text
+		// colouring through their own theme.
+		bottomNavigation.setItemIconTintList(null);
+		bottomNavigation.setOnItemSelectedListener(this);
 		bottomNavigation.addOnLayoutChangeListener(this);
-		setAccentColorFromBottomNavigation();
 	}
 
-	protected void setAccentColorFromBottomNavigation()
-	{
-		bottomNavigation.setAccentColor(ResourcesCompat.getColor(getResources(), R.color.main_red, null));
-	}
-
-	private void addTabBarItemToBottomTabs(TabbedPageDescriptor descriptor)
+	private void addTabBarItemToBottomTabs(int position, TabbedPageDescriptor descriptor)
 	{
 		final Resources resources = getResources();
 		final int iconWidthHeight = (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 24f, resources.getDisplayMetrics());
 		final String iconSrc = ImageHelper.getImageSrc(descriptor.getTabBarItem().getImage(), iconWidthHeight, iconWidthHeight);
 		final String itemName = UiSettings.getInstance().getTextProcessor().process(descriptor.getTabBarItem().getTitle());
 		tabTitles.add(itemName);
-		final AHBottomNavigationItem navItem = new AHBottomNavigationItem(itemName, R.drawable.ic_collapse);
-		bottomNavigation.addItem(navItem);
+		final MenuItem navItem = bottomNavigation.getMenu().add(Menu.NONE, position, position, itemName);
+		navItem.setIcon(R.drawable.ic_collapse);
 
 		if (iconSrc != null)
 		{
@@ -119,8 +112,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			     {
 				     @Override public void onResourceReady(@NonNull Bitmap resource, @Nullable Transition<? super Bitmap> transition)
 				     {
-					     navItem.setDrawable(new BitmapDrawable(resources, resource));
-					     bottomNavigation.refresh();
+					     navItem.setIcon(new BitmapDrawable(resources, resource));
 				     }
 
 				     @Override public void onLoadCleared(@Nullable Drawable placeholder)
@@ -173,15 +165,16 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 	/**
 	 * Calls the content description update and changes the section title
 	 *
-	 * @param position Position of the tab
-	 * @param wasSelected Selected tab
-	 * @return
+	 * @param item The selected menu item
+	 * @return true if the selection was handled
 	 */
 	@Override
-	public boolean onTabSelected(int position, boolean wasSelected)
+	public boolean onNavigationItemSelected(@NonNull MenuItem item)
 	{
+		int position = item.getItemId();
 		viewPager.setCurrentItem(position);
 		selectedTab = position;
+		setTabItemContentDescriptions();
 
 		if (getActivity() != null && ((AppCompatActivity)getActivity()).getSupportActionBar() != null)
 		{    //Hide the back arrow in the main activity
@@ -189,7 +182,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 			if (actionBar != null)
 			{
 				actionBar.setDisplayHomeAsUpEnabled(false);
-				actionBar.setTitle(bottomNavigation.getItem(position).getTitle(getContext()));
+				actionBar.setTitle(item.getTitle());
 			}
 		}
 		return true;
@@ -207,10 +200,11 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 	 */
 	private void setTabItemContentDescriptions()
 	{
-		int tabCount = bottomNavigation.getItemsCount();
+		int tabCount = bottomNavigation.getMenu().size();
 		for (int bottomTabIdx = 0; bottomTabIdx < tabCount; bottomTabIdx++)
 		{
-			View tab = bottomNavigation.getViewAtPosition(bottomTabIdx);
+			MenuItem menuItem = bottomNavigation.getMenu().getItem(bottomTabIdx);
+			View tab = bottomNavigation.findViewById(menuItem.getItemId());
 			if (tab != null)
 			{
 				String formatString = selectedTab == bottomTabIdx ? getString(R.string.bottom_navigation_tab_selected) : getString(R.string.bottom_navigation_tab);
@@ -224,7 +218,7 @@ public class StormBottomTabsFragment extends StormTabbedFragment implements AHBo
 	@Override
 	public void switchToTab(int index)
 	{
-		bottomNavigation.setCurrentItem(index);
+		bottomNavigation.setSelectedItemId(index);
 	}
 
 	@Override public void onSaveInstanceState(Bundle outState)

--- a/library/src/main/java/com/cube/storm/ui/view/NonSwipeableViewPager.java
+++ b/library/src/main/java/com/cube/storm/ui/view/NonSwipeableViewPager.java
@@ -1,0 +1,38 @@
+package com.cube.storm.ui.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import androidx.viewpager.widget.ViewPager;
+
+/**
+ * A {@link ViewPager} that disables swiping between pages. Page changes are driven exclusively
+ * through the bottom navigation. Replaces the legacy {@code AHBottomNavigationViewPager}.
+ */
+public class NonSwipeableViewPager extends ViewPager
+{
+	public NonSwipeableViewPager(Context context)
+	{
+		super(context);
+	}
+
+	public NonSwipeableViewPager(Context context, AttributeSet attrs)
+	{
+		super(context, attrs);
+	}
+
+	@Override
+	public boolean onInterceptTouchEvent(MotionEvent event)
+	{
+		// Never intercept touch events so swiping is disabled
+		return false;
+	}
+
+	@Override
+	public boolean onTouchEvent(MotionEvent event)
+	{
+		// Do not handle swipe gestures
+		return false;
+	}
+}

--- a/library/src/main/res/layout/tabbed_page_bottom_fragment_view.xml
+++ b/library/src/main/res/layout/tabbed_page_bottom_fragment_view.xml
@@ -6,15 +6,16 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 >
-	<com.aurelhubert.ahbottomnavigation.AHBottomNavigation
+	<com.google.android.material.bottomnavigation.BottomNavigationView
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:id="@+id/bottom_tabs"
 		android:layout_alignParentBottom="true"
 		android:elevation="4dp"
+		app:labelVisibilityMode="labeled"
 	/>
 
-	<com.aurelhubert.ahbottomnavigation.AHBottomNavigationViewPager
+	<com.cube.storm.ui.view.NonSwipeableViewPager
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
 		android:id="@+id/view_pager"


### PR DESCRIPTION
## Summary

Removes the unmaintained `com.github.aurelhubert:ahbottomnavigation` dependency and replaces it with Material's `BottomNavigationView` (already available via `com.google.android.material:material`).

## Changes

**Library**
- `build.gradle`: dropped the `ahbottomnavigation` dependency.
- `tabbed_page_bottom_fragment_view.xml`: `AHBottomNavigation` → `com.google.android.material.bottomnavigation.BottomNavigationView`; `AHBottomNavigationViewPager` → new `NonSwipeableViewPager`.
- `NonSwipeableViewPager` (new): a `ViewPager` subclass that disables swipe gestures, preserving the previous behaviour (page changes driven only by the bottom nav). Kept on the legacy `ViewPager` because `StormTabbedFragment`/`StormPageAdapter` (a `FragmentPagerAdapter`) depend on it.
- `StormBottomTabsFragment`: ported from `AHBottomNavigation.OnTabSelectedListener` to `NavigationBarView.OnItemSelectedListener`; menu-based tabs (item id = position), `LABEL_VISIBILITY_LABELED`, Glide-loaded icons via `MenuItem.setIcon`, and content descriptions via the item views. Icons are left untinted (`setItemIconTintList(null)`) so consuming apps drive colouring through their own theme. 5-tab cap + overflow menu behaviour preserved.

**Example**
- Added a Material `Bridge` theme (`Theme.StormExample`) so the storm activities can host `BottomNavigationView` (the previous `Theme.AppCompat` theme would crash at inflation). Keeps the existing DarkActionBar look.
- Demonstrates an app-level gray override of the bottom-nav colour via theme.

## Notes
- Icon colouring is intentionally theme-driven in the library; the example's gray applies to the labels (the library nulls the icon tint so loaded icons keep their natural colours).

## Testing
- `:library:compileReleaseJavaWithJavac` — BUILD SUCCESSFUL
- `:example:processDebugResources` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)