### PR TITLE
:HIGH: Fix/remove unused webactivity code [Medium PR]

### DIFF
--- a/library/src/main/java/com/cube/storm/ui/activity/StormWebActivity.java
+++ b/library/src/main/java/com/cube/storm/ui/activity/StormWebActivity.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.FileProvider;
 import androidx.appcompat.app.AppCompatActivity;
@@ -56,13 +57,17 @@ public class StormWebActivity extends AppCompatActivity
 	public void launchChromeCustomTabs(@NonNull String url)
 	{
 		CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-		builder.addDefaultShareMenuItem();
+		builder.setShareState(CustomTabsIntent.SHARE_STATE_ON);
 
 		int toolbarColor = getToolbarColor();
 
 		if (toolbarColor != 0)
 		{
-			builder.setToolbarColor(toolbarColor);
+			builder.setDefaultColorSchemeParams(
+				new CustomTabColorSchemeParams.Builder()
+					.setToolbarColor(toolbarColor)
+					.build()
+			);
 		}
 
 		builder.setStartAnimations(this, R.anim.slide_in_right, R.anim.slide_out_left);
@@ -70,7 +75,7 @@ public class StormWebActivity extends AppCompatActivity
 
 		Uri uri = Uri.parse(url);
 
-		if (uri.getScheme().startsWith("file"))
+		if (uri.getScheme() != null && uri.getScheme().startsWith("file") && uri.getPath() != null)
 		{
 			uri = FileProvider.getUriForFile(this, getApplicationContext().getPackageName() + ".provider", new File(uri.getPath()));
 		}
@@ -84,11 +89,12 @@ public class StormWebActivity extends AppCompatActivity
 	{
 		TypedValue typedValue = new TypedValue();
 
-		TypedArray a = obtainStyledAttributes(typedValue.data, new int[] {R.attr.colorPrimary});
-		int color = a.getColor(0, 0);
+        int color = 0;
+        try (TypedArray a = obtainStyledAttributes(typedValue.data, new int[]{R.attr.colorPrimary}))
+		{
+            color = a.getColor(0, 0);
+        }
 
-		a.recycle();
-
-		return color;
+        return color;
 	}
 }

--- a/library/src/main/java/com/cube/storm/ui/activity/StormWebActivity.java
+++ b/library/src/main/java/com/cube/storm/ui/activity/StormWebActivity.java
@@ -3,27 +3,15 @@ package com.cube.storm.ui.activity;
 import android.content.Intent;
 import android.content.res.TypedArray;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.FileProvider;
-import androidx.core.view.MenuItemCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.TypedValue;
-import android.view.KeyEvent;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.Window;
-import android.webkit.WebChromeClient;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
-import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.cube.storm.ui.R;
@@ -38,19 +26,9 @@ import java.io.File;
  * @author Alan Le Fournis
  * @project LightningUi
  */
-public class StormWebActivity extends AppCompatActivity implements OnClickListener
+public class StormWebActivity extends AppCompatActivity
 {
 	public static final String EXTRA_FILE_NAME = "extra_file_name";
-	public static final String EXTRA_TITLE = "extra_title";
-
-	public View mWeb;
-	public View mShare;
-	public View mBack;
-	public View mForward;
-	public View mClose;
-	public View mButtonContainer;
-
-	private WebView webView;
 
 	@Override protected void onCreate(Bundle savedInstanceState)
 	{
@@ -67,84 +45,9 @@ public class StormWebActivity extends AppCompatActivity implements OnClickListen
 			return;
 		}
 
-		if (chromeCustomTabsSupported())
-		{
-			launchChromeCustomTabs(url);
-			finish();
-			return;
-		}
-
-		String title = getIntent() != null ? getIntent().getStringExtra(EXTRA_TITLE) : null;
-
-		if (!TextUtils.isEmpty(title))
-		{
-			setTitle(title);
-		}
-
-		setContentView(R.layout.web_view);
-
-		mButtonContainer = findViewById(R.id.button_container);
-		mWeb = findViewById(R.id.icon_web);
-		mBack = findViewById(R.id.icon_back);
-		mForward = findViewById(R.id.icon_forward);
-		mClose = findViewById(R.id.icon_close);
-		mShare = findViewById(R.id.icon_share);
-		webView = (WebView)findViewById(R.id.web_view);
-
-		mWeb.setOnClickListener(this);
-		mBack.setOnClickListener(this);
-		mForward.setOnClickListener(this);
-		mClose.setOnClickListener(this);
-		mShare.setOnClickListener(this);
-
-		WebSettings settings = webView.getSettings();
-		settings.setJavaScriptEnabled(true);
-		settings.setBuiltInZoomControls(true);
-		settings.setLoadWithOverviewMode(true);
-		settings.setUseWideViewPort(true);
-		settings.setDisplayZoomControls(false);
-
-		final ProgressBar progressBar = (ProgressBar)findViewById(R.id.progress_bar);
-		webView.setWebViewClient(new WebViewClient());
-		webView.setWebChromeClient(new WebChromeClient()
-		{
-			@Override public void onProgressChanged(WebView view, int progress)
-			{
-				if (progress < 100 && progressBar.getVisibility() == View.GONE)
-				{
-					progressBar.setVisibility(View.VISIBLE);
-				}
-
-				progressBar.setProgress(progress);
-				if (progress == 100)
-				{
-					progressBar.setVisibility(View.GONE);
-				}
-
-				super.onProgressChanged(view, progress);
-			}
-		});
-
-		if (savedInstanceState != null)
-		{
-			webView.restoreState(savedInstanceState);
-		}
-		else
-		{
-			webView.loadUrl(url);
-		}
-	}
-
-	/**
-	 * Is chrome custom tabs supported for this SDK version?
-	 * More specifically, is the Chrome app supported for this SDK version?
-	 * @return boolean where true means that chrome custom tabs is supported and false meaning it is not supported
-	 */
-	private boolean chromeCustomTabsSupported()
-	{
-		// Chrome is only supported on Jelly Bean and above
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
-	}
+		launchChromeCustomTabs(url);
+		finish();
+    }
 
 	/**
 	 * Launches a chrome custom tab with the given {@link String} url
@@ -187,94 +90,5 @@ public class StormWebActivity extends AppCompatActivity implements OnClickListen
 		a.recycle();
 
 		return color;
-	}
-
-	@Override public void onClick(View v)
-	{
-		if (v == mWeb)
-		{
-			Intent i = new Intent(Intent.ACTION_VIEW);
-			i.setData(Uri.parse(webView.getUrl() == null ? getIntent().getExtras().getString(EXTRA_FILE_NAME) : webView.getUrl()));
-			startActivity(i);
-		}
-		else if (v == mBack)
-		{
-			webView.goBack();
-		}
-		else if (v == mForward)
-		{
-			webView.goForward();
-		}
-		else if (v == mClose)
-		{
-			finish();
-		}
-		else if (v == mShare)
-		{
-			Intent shareIntent = new Intent(Intent.ACTION_SEND);
-			shareIntent.putExtra(Intent.EXTRA_TEXT, webView.getUrl());
-			shareIntent.setType("text/plain");
-			startActivity(shareIntent);
-		}
-	}
-
-	@Override public void onSaveInstanceState(Bundle savedInstanceState)
-	{
-		webView.saveState(savedInstanceState);
-		super.onSaveInstanceState(savedInstanceState);
-	}
-
-	@Override protected void onRestoreInstanceState(Bundle savedInstanceState)
-	{
-		super.onRestoreInstanceState(savedInstanceState);
-		webView.restoreState(savedInstanceState);
-	}
-
-	@Override public boolean onCreateOptionsMenu(Menu menu)
-	{
-		MenuItem back = menu.add(0, 2, 0, "Back");
-		MenuItem forward = menu.add(0, 3, 0, "Forward");
-		MenuItem refresh = menu.add(0, 1, 0, "Refresh");
-		MenuItem open = menu.add(0, 4, 0, "Open external");
-
-		MenuItemCompat.setShowAsAction(back, MenuItemCompat.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
-		MenuItemCompat.setShowAsAction(forward, MenuItemCompat.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
-		MenuItemCompat.setShowAsAction(refresh, MenuItemCompat.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
-		MenuItemCompat.setShowAsAction(open, MenuItemCompat.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW);
-
-		return super.onCreateOptionsMenu(menu);
-	}
-
-	@Override public boolean onKeyDown(int keyCode, KeyEvent event)
-	{
-		if ((keyCode == KeyEvent.KEYCODE_BACK) && webView.canGoBack())
-		{
-			webView.goBack();
-			return true;
-		}
-
-		return super.onKeyDown(keyCode, event);
-	}
-
-	@Override public boolean onOptionsItemSelected(MenuItem item)
-	{
-		if (item.getItemId() == 4)
-		{
-			onClick(mWeb);
-		}
-		else if (item.getItemId() == 2)
-		{
-			onClick(mBack);
-		}
-		else if (item.getItemId() == 3)
-		{
-			webView.goForward();
-		}
-		else if (item.getItemId() == 1)
-		{
-			webView.reload();
-		}
-
-		return super.onOptionsItemSelected(item);
 	}
 }


### PR DESCRIPTION
## What?

Fixes:
 - Updates `StormWebActivity.java` to remove unreachable logic relating to views 
 - Fixes warnings in `StormWebActivity.java` 

## Why?

The `onCreate` method of `StormWebActivity.java` contained the lines:

```java
		if (chromeCustomTabsSupported())
		{
			launchChromeCustomTabs(url);
			finish();
			return;
		}
```

Where 

```java
	private boolean chromeCustomTabsSupported()
	{
		// Chrome is only supported on Jelly Bean and above
		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
	}
```

However, the lib now has `minSdkVersion = 23`, which means `Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN` is always true.

So effectively, all the code below this point was unreachable code anyway.
This PR therefore removes all of that unreachable code, and it also fixes some warnings.